### PR TITLE
minted and owned tabs on profile page

### DIFF
--- a/packages/frontend/src/modules/Profile/index.tsx
+++ b/packages/frontend/src/modules/Profile/index.tsx
@@ -520,8 +520,8 @@ export default function Profile() {
                     classnames(
                       'w-4/12  py-5 text-sm leading-2 font-medium text-blue-700 mb-10',
                       selected
-                        ? 'dark:text-white border-b-2 border-indigo-600 text-white'
-                        : 'dark:text-white hover:bg-white/[0.12] hover:text-white'
+                        ? 'dark:text-white border-b-2 border-indigo-600 dark:text-white'
+                        : 'dark:text-white hover:bg-white/[0.12] hover:dark:text-white'
                     )
                   }
                 >


### PR DESCRIPTION
On the profile page you can now filter by minted and owned

(FYI, I don't have the ability to mint ATM, so if someone else could test on their system that would be awesome)
<img width="100" alt="Screen Shot 2022-02-07 at 7 10 38 PM" src="https://user-images.githubusercontent.com/17347501/152898910-39ae7deb-f861-44cf-86a1-cc4585570578.png">

