### PR TITLE
fix: footer position always in bottom

### DIFF
--- a/packages/frontend/src/components/ScreenWrapper/index.tsx
+++ b/packages/frontend/src/components/ScreenWrapper/index.tsx
@@ -8,9 +8,11 @@ interface ScreenWrapperProps {
 
 export default function ScreenWrapper({ children }: ScreenWrapperProps) {
   return (
-    <div className="relative h-full bg-slate-100 dark:bg-black flex flex-col">
-      <Navbar />
-      {children}
+    <div className="bg-slate-100 dark:bg-black flex flex-col">
+      <div className="min-h-screen grow">
+        <Navbar />
+        {children}
+      </div>
       <Footer />
     </div>
   );


### PR DESCRIPTION
Fix footer to stay out of sight on all pages.

Side note: Footer color looks a little off on dark mode, it might need a different shade for that.