### PR TITLE
fix: profile redirect edge cases

### DIFF
--- a/packages/frontend/src/lib/helpers/validators.ts
+++ b/packages/frontend/src/lib/helpers/validators.ts
@@ -1,21 +1,29 @@
+type RequiredFunc = (value: string | number) => string | undefined;
+export const required: RequiredFunc = (value) => (value ? undefined : 'Required');
 
-type RequiredFunc = (value: string | number) => string | undefined
-export const required: RequiredFunc = (value) => value ? undefined : "Required";
+type GreaterThanFunc = (min: number) => (value: number) => string | undefined;
+export const greaterThan: GreaterThanFunc = (min) => (value) =>
+  value > min ? undefined : `Must be greater than ${min}`;
 
-type GreaterThanFunc = (min: number) => (value: number) => string | undefined
-export const greaterThan: GreaterThanFunc = min => value => value > min ? undefined : `Must be greater than ${min}`;
+export const greaterThanOrEqualTo: GreaterThanFunc = (min) => (value) =>
+  value >= min ? undefined : `Must be greater than or equal to ${min}`;
 
-export const greaterThanOrEqualTo: GreaterThanFunc = min => value => value >= min ? undefined : `Must be greater than or equal to ${min}`
+type InBetween = (min: number, max: number) => (value: number) => string | undefined;
+export const inBetween: InBetween = (min, max) => (value) =>
+  value >= min && value <= max ? undefined : `Must be between ${min} and ${max}`;
 
-type InBetween = (min: number, max: number) => (value: number) => string | undefined
-export const inBetween: InBetween = (min, max) => value => value >= min && value <= max ? undefined : `Must be between ${min} and ${max}`;
-
-type ValidateDate = (availabilityFrom: number, availabilityTo: number, duration: number) => string | undefined
+type ValidateDate = (
+  availabilityFrom: number,
+  availabilityTo: number,
+  duration: number
+) => string | undefined;
 export const validateDate: ValidateDate = (availabilityFrom, availabilityTo, duration) =>
   availabilityTo === 0 ||
-    availabilityFrom === 0 ||
-    (availabilityTo > availabilityFrom &&
-      duration * 3600 <= availabilityTo - availabilityFrom)
-    ?
-    undefined :
-    "End of availability date must be later than beginning of availability plus duration (number of hours)"
+  availabilityFrom === 0 ||
+  (availabilityTo > availabilityFrom && duration * 3600 <= availabilityTo - availabilityFrom)
+    ? undefined
+    : 'End of availability date must be later than beginning of availability plus duration (number of hours)';
+
+type IsOwner = (path: string, address: string | undefined, ens: string | undefined) => boolean;
+export const isOwner: IsOwner = (path, address, ens) =>
+  path.toLowerCase() === address?.toLowerCase() || path.toLowerCase() === ens?.toLowerCase();


### PR DESCRIPTION
Re-add the ability to directly access aika.market/profile/<ensname>.eth

Profile will auto-reload when the wallet changes, but only if the user is on their current profile. This way the user can connect/change wallets without losing their place on the site when browsing profiles or nfts