### PR TITLE
Add max width for NFTDetails

### DIFF
--- a/packages/frontend/src/modules/NFTDetails/index.tsx
+++ b/packages/frontend/src/modules/NFTDetails/index.tsx
@@ -322,7 +322,7 @@ export default function NFTDetails() {
             </div>
           </div>
         </Dialog>
-        <div className="flex flex-col sm:flex-row  gap-10 ">
+        <div className="flex flex-col sm:flex-row gap-10 max-w-7xl m-auto">
           {/** Column 1: NFT Image + buy/sell/redeem options */}
           <div className="flex w-full sm:w-1/3 md:w-1/4 flex-col gap-5 ">
             <div className="w-full">


### PR DESCRIPTION
Fixes https://github.com/WeAreNewt/NonFungibleTime/issues/259

Before | After
--- | ---
<img width="2993" alt="max-width before" src="https://user-images.githubusercontent.com/3699047/157096425-e10998a9-285e-4c8c-9801-ef72b2c19b0c.png"> |  <img width="2990" alt="max-width after" src="https://user-images.githubusercontent.com/3699047/157096440-fefab905-623d-4a47-a8b4-e84bce16f9f3.png">

